### PR TITLE
Stop fetching csv-sniffer directly from GitHub

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "csv-parse": "^4.14.2",
-    "csv-sniffer": "github:luav/npm-csv-sniffer",
+    "csv-sniffer": "^0.1.1",
     "readable-stream": "^3.6.0"
   },
   "optionalDependencies": {


### PR DESCRIPTION
This uses the published package directly, which should be exactly the same